### PR TITLE
dyalog: update to version 18

### DIFF
--- a/dyalog/dyalog.nix
+++ b/dyalog/dyalog.nix
@@ -10,13 +10,13 @@ let
 in
 stdenv.mkDerivation rec {
   src = fetchurl {
-    url = "https://www.dyalog.com/uploads/php/download.dyalog.com/download.php?file=linux_64_${version}_unicode.x86_64.deb";
-      sha256 = "1117g1pgsqwf5rz6z90jwyf7a2wr5x6p1xamjhbrka0c09csd1b4";
+    url = "https://www.dyalog.com/uploads/php/download.dyalog.com/download.php?file=${shortVersion}/linux_64_${version}_unicode.x86_64.deb";
+      sha256 = "1i58yc229rqba9rgjqn9i09mf8kn32qhds0x2z3f9vpjzfj7a936";
   };
 
   name = "dyalog-${version}";
 
-  version = "17.1.36845";
+  version = "18.0.38756";
 
   shortVersion = stdenv.lib.concatStringsSep "." (stdenv.lib.take 2 (stdenv.lib.splitString "." version));
 

--- a/ride/ride.nix
+++ b/ride/ride.nix
@@ -5,7 +5,7 @@
   cups,
   dbus_daemon,
   dpkg,
-  electron,
+  electron_6,
   expat,
   fetchurl,
   fontconfig,
@@ -62,21 +62,21 @@ let
   electronLauncher = writeScript "rideWrapper" ''
     #!${runtimeShell}
     set -e
-    ${electron}/bin/electron TODO/resources/app
+    ${electron_6}/bin/electron TODO/resources/app
   '';
   drv = stdenv.mkDerivation rec {
     name = "ride-${version}";
 
-    version = "4.2.3437-1";
+    version = "4.3.3463-1";
 
     shortVersion = stdenv.lib.concatStringsSep "." (stdenv.lib.take 2 (stdenv.lib.splitString "." version));
 
-    # deal with 4.2.3437 having a '-1' suffix...
+    # deal with 4.3.3463 having a '-1' suffix...
     cleanedVersion = builtins.replaceStrings ["-1"] [""] version;
 
     src = fetchurl {
       url = "https://github.com/Dyalog/ride/releases/download/v${cleanedVersion}/ride-${version}_amd64.deb";
-      sha256 = "0pw51z8kifmbss6vnljhskf9k02iw52p5r3rfj9kaapprifdk66i";
+      sha256 = "0rkh7c1m1xflapb510vjv4d1q4sqj63y5mlrhnqxgz1jaqz6aap7";
     };
 
     nativeBuildInputs = [ dpkg ];


### PR DESCRIPTION
Since RIDE froze at startup with the current version of electron (electron_10), I hardcoded it to the version used upstream (electron_6).