### PR TITLE
Build RIDE from Dyalog/ride instead of patching .deb release

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,21 +2,40 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1685533922,
-        "narHash": "sha256-y4FCQpYafMQ42l1V+NUrMel9RtFtZo59PzdzflKR/lo=",
+        "lastModified": 1685865905,
+        "narHash": "sha256-XJZ/o17eOd2sEsGif+/MQBnfa2DKmndWgJyc7CWajFc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3a70dd92993182f8e514700ccf5b1ae9fc8a3b8d",
+        "rev": "e7603eba51f2c7820c0a182c6bbb351181caa8e7",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
+        "owner": "NixOS",
+        "ref": "nixos-23.05-small",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "ride": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1684338347,
+        "narHash": "sha256-j3flZ1sKsYRkJ79yxmR4NKcOSf66bHsCXiupKhUAFcQ=",
+        "owner": "Dyalog",
+        "repo": "ride",
+        "rev": "246649aad81daadfa8ac7e0af7c0206e49b4e337",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Dyalog",
+        "repo": "ride",
+        "type": "github"
       }
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "ride": "ride"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1679734080,
-        "narHash": "sha256-z846xfGLlon6t9lqUzlNtBOmsgQLQIZvR6Lt2dImk1M=",
+        "lastModified": 1685533922,
+        "narHash": "sha256-y4FCQpYafMQ42l1V+NUrMel9RtFtZo59PzdzflKR/lo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dbf5322e93bcc6cfc52268367a8ad21c09d76fea",
+        "rev": "3a70dd92993182f8e514700ccf5b1ae9fc8a3b8d",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,16 +1,21 @@
 {
-  outputs = {
-    self,
-    nixpkgs,
-  }: let
-    system = "x86_64-linux";
-    pkgs = nixpkgs.legacyPackages.${system};
-  in {
-    packages.${system} = rec {
-      dyalog = pkgs.callPackage ./dyalog.nix {};
-      ride = pkgs.callPackage ./ride.nix {};
+  inputs.nixpkgs.url = github:NixOS/nixpkgs/nixos-23.05-small;
+  inputs.ride.url = github:Dyalog/ride;
+  inputs.ride.flake = false;
 
-      default = pkgs.symlinkJoin { name = "dyalog-and-ride"; paths = [dyalog ride]; };
+  outputs = { self, nixpkgs, ride }:
+    let
+      system = "x86_64-linux";
+      pkgs = import nixpkgs { inherit system; };
+      ride-src = ride;
+      lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+    in
+    {
+      packages.${system} = rec {
+        dyalog = pkgs.callPackage ./dyalog.nix { };
+        ride = pkgs.callPackage ./ride.nix { src = ride-src; rev = lock.nodes.ride.locked.rev; };
+
+        default = pkgs.symlinkJoin { name = "dyalog-and-ride"; paths = [ dyalog ride ]; };
+      };
     };
-  };
 }

--- a/ride.nix
+++ b/ride.nix
@@ -1,4 +1,6 @@
-{ lib
+{ src
+, rev
+, lib
 , fetchFromGitHub
 , buildNpmPackage
 , makeWrapper
@@ -8,41 +10,37 @@
 
 let
   pname = "ride";
-  version = "4.5.3770";
-  rev = "246649aad81daadfa8ac7e0af7c0206e49b4e337";
 
-  src = fetchFromGitHub {
-    inherit rev;
-    owner = "Dyalog";
-    repo = pname;
-    hash = "sha256-j3flZ1sKsYRkJ79yxmR4NKcOSf66bHsCXiupKhUAFcQ=";
-  };
+  packageInfo = builtins.fromJSON (builtins.readFile (src + "/package.json"));
+
+  version = lib.concatStringsSep "." (lib.take 2 (lib.splitString "." packageInfo.version));
 
   versionJSON = builtins.toJSON {
     versionInfo = {
       inherit version rev;
-      date = "2023-05-17 17:45:47 +0200";
+      date = "unknown (built by Nix)";
     };
   };
+
 in
 buildNpmPackage {
 
   inherit pname version src;
 
-  # Skips the auto-downloaded electron-chromedriver binary
-  postPatch = "sed -i '/spectron/d' package.json";
+  npmInstallFlags = [ "--omit=dev" ];
 
   # Skips the auto-downloaded electron binary
   ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
 
-  npmDepsHash = "sha256-qA+Hzz5dvxLEpPVPCvfngUhfqm897lKQt0DYWDk9PoI=";
+  npmDepsHash = "sha256-mgkOTuspqoM4yZMr2u7f+0qSgzIMz033GXezuPA7rkQ=";
+
   dontNpmBuild = true;
 
   nativeBuildInputs = [ makeWrapper python3 ];
 
   # This is the replacement for the `mk` script in the source repo
   postInstall = ''
-    cd $out/lib/node_modules/ride45
+    cd $out/lib/node_modules/${packageInfo.name}
 
     mkdir $out/app
     cp -r {src,lib,node_modules,D.png,favicon.*,*.html,main.js,package.json} $out/app
@@ -50,13 +48,18 @@ buildNpmPackage {
     mkdir $out/app/style
     cp -r style/{fonts,img,*.css} $out/app/style
 
+    cd $out/app/node_modules
+    rm -r {.bin,monaco-editor/{dev,esm,min-maps}}
+    find . -type f -name '*.map' -exec rm -rf {} +
+    find . -type d -name 'test' -exec rm -rf {} +
+
     rm -r $out/lib
 
     # Generate version-info
     mkdir $out/app/_
     echo 'D=${versionJSON}' > $out/app/_/version.js
     echo ${version} > $out/app/_/version
-  
+
     # Call electron manually
     makeWrapper ${electron}/bin/electron $out/bin/ride \
             --add-flags $out/app


### PR DESCRIPTION
This PR adds build instructions for the RIDE repo, essentially simulating what their `mk` script does.
The `nixpkgs` flake input was also updated, as `npm i` failed without it (probably some new package or something)