### PR TITLE
Fix .NET Bridge

### DIFF
--- a/dyalog.nix
+++ b/dyalog.nix
@@ -7,6 +7,7 @@
 , glib
 , ncurses5
 , unixODBC
+, dotnet-sdk_6
 }:
 
 stdenv.mkDerivation rec {
@@ -40,17 +41,20 @@ stdenv.mkDerivation rec {
     rm -r {RIDEapp,swiftshader,locales}
     rm {lib/htmlrenderer.so,libcef.so,libEGL.so,libGLESv2.so,chrome-sandbox,*.pak,v8_context_snapshot.bin,snapshot_blob.bin,natives_blob.bin}
 
-    # Remove files for .NET support (according to nixpkgs .NET Core 3.1 is EOL and no longer can be installed)
-    rm {libnethost.so,Dyalog.Net.*}
-
     # Remove other miscellaneous files and directories
     rm -r {xfsrc,help,scriptbin,fonts}
     rm {icudtl.dat,magic,dyalog.desktop,mapl,aplkeys.sh,aplunicd.ini,languagebar.json}
 
-    # using flags instead of environment variables ensures that running dyalog with the -script flag works as expected
-    # set a compatible TERM variable, otherwise redrawing is broken
+    # Patch to use .NET 6.0 instead of .NET Core 3.1 (can be removed when Dyalog 19.0 releases)
+    sed -i s/3.1/6.0/g Dyalog.Net.Bridge.{deps,runtimeconfig}.json
+
+    # TERM needs to be set or else redrawing is broken
+    # LD_LIBRARY_PATH is set for .NET Bridge dll to be found
+    # DYALOG needs to be set when using the `-script` flag or else redrawing is broken
     makeWrapper $out/dyalog/dyalog $out/bin/dyalog \
         --set TERM xterm \
+        --set DOTNET_ROOT ${dotnet-sdk_6} \
+        --set LD_LIBRARY_PATH $out/dyalog \
         --add-flags DYALOG=$out/dyalog \
         --add-flags SESSION_FILE=$out/dyalog/default.dse
   '';

--- a/dyalog.nix
+++ b/dyalog.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
 
     # TERM needs to be set or else redrawing is broken
     # LD_LIBRARY_PATH is set for .NET Bridge dll to be found
-    # DYALOG needs to be set when using the `-script` flag or else redrawing is broken
+    # DYALOG needs to be set when using the `-script` flag
     makeWrapper $out/dyalog/dyalog $out/bin/dyalog \
         --set TERM xterm \
         --set DOTNET_ROOT ${dotnet-sdk_6} \


### PR DESCRIPTION
This PR reintroduces .NET support for Dyalog.

First, I replaced the supported .NET version from 3.1 to 6.0
 > https://forums.dyalog.com/viewtopic.php?f=22&t=1863

Using `2250⌶0` I found that `dyalog` couldn't find the `Dyalog.Net.Bridge.dll` shared library. I used `LD_LIBRARY_PATH` to patch that issue.

I also needed to set `DOTNET_ROOT` as the nix store is not the standard install directory.

---
Now `2250⌶0` no longer shows an error.
After running `⎕USING←'System'` I can run `DateTime.Now` and it prints the time correctly.
