### PR TITLE
Clean up and add R support

### DIFF
--- a/dyalog.nix
+++ b/dyalog.nix
@@ -9,25 +9,37 @@
 , unixODBC
 , dotnet-sdk_6
 , withDotnet ? true
+, R
+, rWrapper
+, rscproxy
+, extraRPackages ? [ ]
+, withRConnect ? false
 }:
+let
+  pname = "dyalog";
+  version = "18.2.45405";
+  shortVersion = lib.concatStringsSep "." (lib.take 2 (lib.splitString "." version));
 
-stdenv.mkDerivation rec {
   src = fetchurl {
     url = "https://download.dyalog.com/download.php?file=${shortVersion}/linux_64_${version}_unicode.x86_64.deb";
     sha256 = "sha256-pA/WGTA6YvwG4MgqbiPBLKSKPtLGQM7BzK6Bmyz5pmM=";
   };
 
-  name = "dyalog-${version}";
-  version = "18.2.45405";
+  wrappedR = rWrapper.override {
+    R = R.overrideAttrs (oldAttrs: { nativeBuildInputs = [ autoPatchelfHook ] ++ oldAttrs.nativeBuildInputs; });
+    packages = [ rscproxy ] ++ extraRPackages;
+  };
 
-  shortVersion = lib.concatStringsSep "." (lib.take 2 (lib.splitString "." version));
+in
+stdenv.mkDerivation {
+  inherit pname version shortVersion src;
 
   nativeBuildInputs = [ autoPatchelfHook makeWrapper dpkg ];
 
   buildInputs = [
-    glib
-    ncurses5
-    unixODBC
+    glib # Used by Conga and .NET Bridge
+    ncurses5 # Used by the dyalog binary
+    unixODBC # Used by SQAPL
   ];
 
   unpackPhase = "dpkg-deb -x $src .";
@@ -45,10 +57,12 @@ stdenv.mkDerivation rec {
       ++ lib.optionals withDotnet [
         # .Net Bridge .dll files cannot be hard linked with autoPatchelfHook, but are still runtime dependencies
         "--prefix LD_LIBRARY_PATH : $out/dyalog"
-        # needs to be set, as there is no default install location in NixOS
+        # needs to be set, as there is no default install location when using Nix
         "--set DOTNET_ROOT ${dotnet-sdk_6}"
-      ];
-
+      ]
+      ++ lib.optional withRConnect
+        # dyalog uses the PATH to determine the location of R files
+        "--prefix PATH : ${wrappedR}/bin";
     in
     ''
       mkdir -p $out/dyalog $out/bin
@@ -56,21 +70,38 @@ stdenv.mkDerivation rec {
 
       cd $out/dyalog
 
-      # Remove the pre-packaged RIDE build and everything that uses CEF
-      rm -r {RIDEapp,swiftshader,locales}
-      rm {lib/htmlrenderer.so,libcef.so,libEGL.so,libGLESv2.so,chrome-sandbox,*.pak,v8_context_snapshot.bin,snapshot_blob.bin,natives_blob.bin}
+
+      # File removal partially based on `https://github.com/Dyalog/DyalogDocker/blob/master/rmfiles.sh`
+
+      # Remove the zero-footprint RIDE
+      rm -r RIDEapp
+
+      # Remove everything connected to CEF
+      rm -r locales swiftshader
+      rm lib/htmlrenderer.so libcef.so libEGL.so libGLESv2.so
+      rm chrome-sandbox natives_blob.bin snapshot_blob.bin v8_context_snapshot.bin *.pak
+
+      # Remove workspaces that are not really useful
+      rm ws/{apl2in,apl2pcin,ddb,display,eval,fonts,ftp,groups,max,min,ops,quadna,smdemo,smdesign,smtutor,tutor,tube,xfrcode,xlate}.dws
+
+      # Remove other miscellaneous files and directories
+      rm -r dwa fonts help Samples scriptbin TestCertificates xfsrc xflib
+      rm lib/ademo64.so lib/testcallback.so
+      rm aplkeys.sh aplunicd.ini BuildID dyalog.desktop dyalog.rt dyalog.svg icudtl.dat languagebar.json magic mapl
+
 
       # Patch to use .NET 6.0 instead of .NET Core 3.1 (can be removed when Dyalog 19.0 releases)
       sed -i s/3.1/6.0/g Dyalog.Net.Bridge.{deps,runtimeconfig}.json
-      
-      # Remove other miscellaneous files and directories
-      rm -r {xfsrc,help,scriptbin,fonts}
-      rm {icudtl.dat,magic,dyalog.desktop,mapl,aplkeys.sh,aplunicd.ini,languagebar.json}
- 
+
+
       makeWrapper $out/dyalog/dyalog $out/bin/dyalog ${lib.concatStringsSep " " wrapperArgs}
     ''
     + lib.optionalString (!withDotnet) ''
       # Remove .NET files
       rm {libnethost.so,Dyalog.Net.Bridge.*}
+    ''
+    + lib.optionalString (!withRConnect) ''
+      # Remove RConnect workspace
+      rm ws/rconnect.dws
     '';
 }

--- a/flake.lock
+++ b/flake.lock
@@ -35,7 +35,24 @@
     "root": {
       "inputs": {
         "nixpkgs": "nixpkgs",
-        "ride": "ride"
+        "ride": "ride",
+        "rscproxy": "rscproxy"
+      }
+    },
+    "rscproxy": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1595847950,
+        "narHash": "sha256-SVoBoAWUmQ+jWaTG7hdmyRq6By4RnmmgWZXoua19/Kg=",
+        "owner": "Dyalog",
+        "repo": "rscproxy",
+        "rev": "31de3323fb8596ff5ecbf4bacd030e542cfd8133",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Dyalog",
+        "repo": "rscproxy",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -2,19 +2,24 @@
   inputs.nixpkgs.url = github:NixOS/nixpkgs/nixos-23.05-small;
   inputs.ride.url = github:Dyalog/ride;
   inputs.ride.flake = false;
+  inputs.rscproxy.url = github:Dyalog/rscproxy;
+  inputs.rscproxy.flake = false;
 
-  outputs = { self, nixpkgs, ride }:
+  outputs = inputs:
     let
       system = "x86_64-linux";
-      pkgs = import nixpkgs { inherit system; };
-      ride-src = ride;
+      pkgs = import inputs.nixpkgs { inherit system; };
+
       lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+
+      rscproxy = pkgs.rPackages.buildRPackage { name = "rscproxy"; src = inputs.rscproxy; };
+
+      dyalog = pkgs.callPackage ./dyalog.nix { inherit rscproxy; };
+      ride = pkgs.callPackage ./ride.nix { src = inputs.ride; rev = lock.nodes.ride.locked.rev; };
     in
     {
-      packages.${system} = rec {
-        dyalog = pkgs.callPackage ./dyalog.nix { };
-        ride = pkgs.callPackage ./ride.nix { src = ride-src; rev = lock.nodes.ride.locked.rev; };
-
+      packages.${system} = {
+        inherit dyalog ride;
         default = pkgs.symlinkJoin { name = "dyalog-and-ride"; paths = [ dyalog ride ]; };
       };
     };


### PR DESCRIPTION
This PR adds support for working with R inside dyalog using the `ws/rconnect.dws` workspace. It is disabled by default as it requires a modified build of the `R` derivation which takes a long time.

The reason for the modified R build is that dyalog searches for the `libR.so` library by using `ldd` on the R executable, which, for some reason, didn't actually find `libR.so`. The solution was to just include `autoPatchelfHook` in the build process which can actually find `libR.so` and patch the binary.

Now the following works (if `withRConnect` is set to true):
```apl
)load rconnect
r←⎕NEW R
r.init   ⍝ Would have errored before this PR
⎕←r.x'2*c(3,4,5)'    ⍝ result: 6 8 10
⎕←r.x'⍵*⍵+⍵' 2 4 1   ⍝ result: 9
```

---

I also did some cleanup.
- In `flake.nix` I removed the recursive set
- In `dyalog.nix` I removed the recursive set and added more comments. I also found that the dyalog docker image has a [pretty similar removal script](https://github.com/Dyalog/DyalogDocker/blob/master/rmfiles.sh), so I cross-referenced them and found more things to remove.