### PR TITLE
Fix HTMLRenderer

### DIFF
--- a/dyalog.nix
+++ b/dyalog.nix
@@ -82,9 +82,16 @@ stdenv.mkDerivation {
         # needs to be set, as there is no default install location when using Nix
         "--set DOTNET_ROOT ${dotnet-sdk_6}"
       ]
+      ++ lib.optionals withHTMLRenderer [
+        # makes the next flag be passed to CEF
+        "--add-flags -cef"
+        # disable creation of the GPUCache directory
+        "--add-flags --disable-gpu-shader-disk-cache"
+      ]
       ++ lib.optional withRConnect
         # dyalog uses the PATH to determine the location of R files
         "--prefix PATH : ${wrappedR}/bin";
+
     in
     ''
       mkdir -p $out/dyalog $out/bin


### PR DESCRIPTION
This PR adds a toggle to enable/disable the `HTMLRenderer` interface, which was previously removed, because it always segfaulted.

---

This took a while to debug, as I made a mistake in an earlier commit, where I put `icudtl.dat` in the miscellaneous files section, whereas it was actually used by `libcef`.
After this I used `coredumpctl gdb` to track down the remaining problem, which was the runtime dependency on `libudev.so`

I tested the simpler examples in the documentation and they seemed to work.
